### PR TITLE
Switching Firefox roles

### DIFF
--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -2,4 +2,4 @@
 - src: pcextreme.mariadb
 - src: geerlingguy.apache
 - src: geerlingguy.php
-- src: arknoll.firefox
+- src: tschifftner.firefox

--- a/tests/test_web_flows.yml
+++ b/tests/test_web_flows.yml
@@ -7,7 +7,7 @@
   vars_files:
     - test_secrets.yml
   roles:
-    - arknoll.firefox
+    - { role: tschifftner.firefox }
   tasks:
     - name: install apt packages
       apt:


### PR DESCRIPTION
Previous role seems unmaintained and yielded deprecation warnings.
